### PR TITLE
add specificity score

### DIFF
--- a/arrival-departure.js
+++ b/arrival-departure.js
@@ -10,12 +10,22 @@ const arrivalDepartureIds = (stopIds, tripIds, routeIds, lineIds, normalizePlatf
 		? normalizePlatform(_.plannedPlatform, _)
 		: null
 
+	// todo: arr time
+	const byStopAndTrip = matrix(stopIds, tripIds)
+	.map(([[stopId, stopSpecif], [tripId, tripSpecif]]) => [
+		versionedId([type, stopId, tripId].join(':')),
+		stopSpecif + tripSpecif + 20,
+	])
+
 	// This assumes that there are no two vehicles
 	// - running for the same route,
 	// - stopping at the same station,
 	// - at the same time.
 	const fuzzyByRoute = !Number.isNaN(when)
-		? matrix(stopIds, routeIds).map(id => [...id, when])
+		? matrix(stopIds, routeIds).map(([[stopId, stopSpecif], [routeId, routeSpecif]]) => [
+			versionedId([type, stopId, routeId, when].join(':')),
+			stopSpecif + routeSpecif + 30,
+		])
 		: []
 
 	// This assumes that there are no two vehicles
@@ -24,14 +34,17 @@ const arrivalDepartureIds = (stopIds, tripIds, routeIds, lineIds, normalizePlatf
 	// - at the same platform,
 	// - at the same time.
 	const fuzzyByLine = !Number.isNaN(when) && platform
-		? matrix(stopIds, lineIds).map(id => [...id, when, platform])
+		? matrix(stopIds, lineIds).map(([[stopId, stopSpecif], [lineId, lineSpecif]]) => [
+			versionedId([type, stopId, lineId, when, platform].join(':')),
+			stopSpecif + lineSpecif + 30,
+		])
 		: []
+
 	return [
-		...matrix(stopIds, tripIds), // todo: arr time
+		...byStopAndTrip,
 		...fuzzyByRoute,
 		...fuzzyByLine
 	]
-	.map(id => versionedId([type, ...id].join(':')))
 }
 
 module.exports = arrivalDepartureIds

--- a/line.js
+++ b/line.js
@@ -4,23 +4,23 @@ const {versionedId} = require('./lib/versioned-id')
 
 const lineIds = (dataSource, normalizeName) => (s) => {
 	return [
-		s.wikidataId || null,
-		s.osmId || null,
-		s.id ? [dataSource, s.id] : null,
+		s.wikidataId ? [s.wikidataId, 10] : null,
+		s.osmId ? [s.osmId, 10] : null,
+		s.id ? [dataSource + ':' + s.id, 20] : null,
 		s.operator && s.operator.id && s.name
-			? [s.operator.id, normalizeName(s.name, s)]
+			? [s.operator.id + ':' + normalizeName(s.name, s), 30]
 			: null,
 		s.product && s.name
-			? [s.product, normalizeName(s.name, s)]
+			? [s.product + ':' + normalizeName(s.name, s), 31]
 			: null,
 		s.mode && s.name
-			? [s.mode, normalizeName(s.name, s)]
+			? [s.mode + ':' + normalizeName(s.name, s), 32]
 			: null,
 		// todo: Onestop ID?
 		// https://github.com/transitland/transitland-datastore/blob/ce4ad9468882dc22a4c6fbe8b84a69da6c4cef90/app/models/route.rb#L234-L244
 	]
 	.filter(id => id !== null)
-	.map(id => versionedId(id.join(':')))
+	.map(([id, specificity]) => [versionedId(id), specificity])
 }
 
 module.exports = lineIds

--- a/operator.js
+++ b/operator.js
@@ -54,9 +54,9 @@ const operatorGeohash = (area) => {
 
 const operatorIds = (dataSource, normalizeName) => (o) => {
 	const ids = [
-		o.wikidataId || null,
-		o.osmId || null,
-		o.id ? dataSource + ':' + o.id : null
+		o.wikidataId ? [o.wikidataId, 10] : null,
+		o.osmId ? [o.osmId, 10] : null,
+		o.id ? [dataSource + ':' + o.id, 20] : null,
 	]
 
 	if (o.serviceArea) {
@@ -71,14 +71,14 @@ const operatorIds = (dataSource, normalizeName) => (o) => {
 		].join(':')
 
 		ids.push(
-			onestopId,
-			[nName, ...grid(lat, lon)].join(':')
+			[onestopId, 30],
+			[[nName, ...grid(lat, lon)].join(':'), 31],
 		)
 	}
 
 	return ids
 	.filter(id => id !== null)
-	.map(versionedId)
+	.map(([id, specificity]) => [versionedId(id), specificity])
 }
 
 module.exports = operatorIds

--- a/stop.js
+++ b/stop.js
@@ -10,26 +10,26 @@ const stopIds = (dataSource, normalizeName) => (s) => {
 	const lon = s.location.longitude
 	// todo: stop code, e.g. like in GTFS?
 	return [
-		s.wikidataId || null,
-		s.osmId || null,
-		dataSource + ':' + s.id,
-		s.station ? dataSource + ':station:' + s.station.id : null,
+		s.wikidataId ? [s.wikidataId, 10] : null,
+		s.osmId ? [s.osmId, 10] : null,
+		[dataSource + ':' + s.id, 20],
 		// overlapping grids to ensure we always match nearby pairs
 		// todo: breaks closer to/further from the equator
-		[nName, ...grid(lat, lon)].join(':'),
-		[nName, ...grid(lat, lon + .001)].join(':'),
-		[nName, ...grid(lat, lon - .001)].join(':'),
-		[nName, ...grid(lat + .001, lon)].join(':'),
-		[nName, ...grid(lat + .001, lon + .001)].join(':'),
-		[nName, ...grid(lat + .001, lon - .001)].join(':'),
-		[nName, ...grid(lat - .001, lon)].join(':'),
-		[nName, ...grid(lat - .001, lon + .001)].join(':'),
-		[nName, ...grid(lat - .001, lon - .001)].join(':')
+		[[nName, ...grid(lat, lon)].join(':'), 30],
+		[[nName, ...grid(lat, lon + .001)].join(':'), 31],
+		[[nName, ...grid(lat, lon - .001)].join(':'), 31],
+		[[nName, ...grid(lat + .001, lon)].join(':'), 31],
+		[[nName, ...grid(lat - .001, lon)].join(':'), 31],
+		[[nName, ...grid(lat + .001, lon + .001)].join(':'), 32],
+		[[nName, ...grid(lat + .001, lon - .001)].join(':'), 32],
+		[[nName, ...grid(lat - .001, lon + .001)].join(':'), 32],
+		[[nName, ...grid(lat - .001, lon - .001)].join(':'), 32],
+		s.station ? [dataSource + ':station:' + s.station.id, 50] : null,
 		// todo: Onestop ID
 		// https://github.com/transitland/transitland-datastore/blob/46fedd0d3293fe61ae04e90d0648187dba86064e/app/models/stop.rb#L387-L398
 	]
 	.filter(id => id !== null)
-	.map(versionedId)
+	.map(([id, specificity]) => [versionedId(id), specificity])
 }
 
 module.exports = stopIds

--- a/test.js
+++ b/test.js
@@ -17,12 +17,11 @@ const normalize = (name, thing) => {
 	].join('')
 }
 
-const beginsWith = str => str2 => str2.slice(0, str.length) === str
-
 test('operator OneStop ID', (t) => {
-	const ids = operatorIds('sauce', normalize)({
+	const op = {
 		type: 'operator',
 		id: 'foo',
+		wikidataId: 'Q99633',
 		name: 'Foo Transit',
 		serviceArea: {
 			type: 'Feature',
@@ -35,10 +34,17 @@ test('operator OneStop ID', (t) => {
 				]]
 			}
 		}
-	})
+	}
+	const ids = operatorIds('sauce', normalize)(op)
 
+	const beginsWith = str => ([str2]) => str2.slice(0, str.length) === str
 	const onestopId = ids.find(beginsWith(`${v}:custom:o:`))
-	t.equal(onestopId, `${v}:custom:o:dn:foo~transitF`)
+	t.deepEqual(ids, [
+		[[v, op.wikidataId].join(':'), 10],
+		[[v, 'sauce', op.id].join(':'), 20],
+		[`${v}:custom:o:dn:foo~transitF`, 30],
+		[[v, normalize(op.name, op), '36.1340', '-82.3110'].join(':'), 31],
+	])
 
 	t.end()
 })
@@ -51,19 +57,19 @@ test('stop IDs', (t) => {
 		location: {latitude: 12.345, longitude: 23.456}
 	})
 	t.deepEqual(ids, [
-		[v, 'sauce', '123'].join(':'), // data src, stop ID
-		[v, 'sauce', 'station:12'].join(':'), // data src, station ID
-		// normalized station name, normalized coords
-		[v, 'bar1', 12.345.toFixed(4), 23.456.toFixed(4)].join(':'),
-		// normalized station name, normalized & shifted coords
-		[v, 'bar1', 12.345.toFixed(4), (23.456 + .001).toFixed(4)].join(':'),
-		[v, 'bar1', 12.345.toFixed(4), (23.456 - .001).toFixed(4)].join(':'),
-		[v, 'bar1', (12.345 + .001).toFixed(4), 23.456.toFixed(4)].join(':'),
-		[v, 'bar1', (12.345 + .001).toFixed(4), (23.456 + .001).toFixed(4)].join(':'),
-		[v, 'bar1', (12.345 + .001).toFixed(4), (23.456 - .001).toFixed(4)].join(':'),
-		[v, 'bar1', (12.345 - .001).toFixed(4), 23.456.toFixed(4)].join(':'),
-		[v, 'bar1', (12.345 - .001).toFixed(4), (23.456 + .001).toFixed(4)].join(':'),
-		[v, 'bar1', (12.345 - .001).toFixed(4), (23.456 - .001).toFixed(4)].join(':'),
+		[[v, 'sauce', '123'].join(':'), 20], // data src, stop ID
+		// normalized stop name, normalized coords
+		[[v, 'bar1', 12.345.toFixed(4), 23.456.toFixed(4)].join(':'), 30],
+		// normalized stop name, normalized & shifted coords
+		[[v, 'bar1', 12.345.toFixed(4), (23.456 + .001).toFixed(4)].join(':'), 31],
+		[[v, 'bar1', 12.345.toFixed(4), (23.456 - .001).toFixed(4)].join(':'), 31],
+		[[v, 'bar1', (12.345 + .001).toFixed(4), 23.456.toFixed(4)].join(':'), 31],
+		[[v, 'bar1', (12.345 - .001).toFixed(4), 23.456.toFixed(4)].join(':'), 31],
+		[[v, 'bar1', (12.345 + .001).toFixed(4), (23.456 + .001).toFixed(4)].join(':'), 32],
+		[[v, 'bar1', (12.345 + .001).toFixed(4), (23.456 - .001).toFixed(4)].join(':'), 32],
+		[[v, 'bar1', (12.345 - .001).toFixed(4), (23.456 + .001).toFixed(4)].join(':'), 32],
+		[[v, 'bar1', (12.345 - .001).toFixed(4), (23.456 - .001).toFixed(4)].join(':'), 32],
+		[[v, 'sauce', 'station:12'].join(':'), 50], // data src, station ID
 	])
 
 	t.end()
@@ -78,20 +84,20 @@ test('line IDs', (t) => {
 		operator: {id: 'foo-bar baz'}
 	})
 	t.deepEqual(ids, [
-		[v, 'sauce', '1a'].join(':'), // data src, line ID
-		[v, 'foo-bar baz', 'some line1'].join(':'), // operator ID, normalized name
-		[v, 'suburban', 'some line1'].join(':'), // product, normalized name
-		[v, 'train', 'some line1'].join(':'), // mode, normalized name
+		[[v, 'sauce', '1a'].join(':'), 20], // data src, line ID
+		[[v, 'foo-bar baz', 'some line1'].join(':'), 30], // operator ID, normalized name
+		[[v, 'suburban', 'some line1'].join(':'), 31], // product, normalized name
+		[[v, 'train', 'some line1'].join(':'), 32], // mode, normalized name
 	])
 
 	t.end()
 })
 
 test('arrival/departure IDs', (t) => {
-	const stopIds = ['some-stop', 'another:stop']
-	const routeIds = ['some-route', 'another:route']
-	const tripIds = ['some-trip', 'another:trip']
-	const lineIds = ['some-line', 'another:line']
+	const stopIds = [['some-stop', 20], ['another:stop', 31]]
+	const routeIds = [['some-route', 10], ['another:route', 20]]
+	const tripIds = [['some-trip', 30], ['another:trip', 30]]
+	const lineIds = [['some-line', 10], ['another:line', 11]]
 	const normalizePlatform = (platform, arrDep) => {
 		return platform.toLowerCase().trim() + arrDep.when[0]
 	}
@@ -105,38 +111,38 @@ test('arrival/departure IDs', (t) => {
 	})
 	t.deepEqual(ids, [
 		// stop ID + trip ID
-		[v, 'arrival', 'some-stop', 'some-trip'].join(':'),
-		[v, 'arrival', 'another:stop', 'some-trip'].join(':'),
-		[v, 'arrival', 'some-stop', 'another:trip'].join(':'),
-		[v, 'arrival', 'another:stop', 'another:trip'].join(':'),
+		[[v, 'arrival', 'some-stop', 'some-trip'].join(':'), 20 + 30 + 20],
+		[[v, 'arrival', 'another:stop', 'some-trip'].join(':'), 31 + 30 + 20],
+		[[v, 'arrival', 'some-stop', 'another:trip'].join(':'), 20 + 30 + 20],
+		[[v, 'arrival', 'another:stop', 'another:trip'].join(':'), 31 + 30 + 20],
 
 		// stop ID + route ID + plannedWhen
-		[v, 'arrival', 'some-stop', 'some-route', 1546333800].join(':'),
-		[v, 'arrival', 'another:stop', 'some-route', 1546333800].join(':'),
-		[v, 'arrival', 'some-stop', 'another:route', 1546333800].join(':'),
-		[v, 'arrival', 'another:stop', 'another:route', 1546333800].join(':'),
+		[[v, 'arrival', 'some-stop', 'some-route', 1546333800].join(':'), 20 + 10 + 30],
+		[[v, 'arrival', 'another:stop', 'some-route', 1546333800].join(':'), 31 + 10 + 30],
+		[[v, 'arrival', 'some-stop', 'another:route', 1546333800].join(':'), 20 + 20 + 30],
+		[[v, 'arrival', 'another:stop', 'another:route', 1546333800].join(':'), 31 + 20 + 30],
 
 		// stop ID + line ID + plannedWhen + plannedPlatform
-		[v, 'arrival', 'some-stop', 'some-line', 1546333800, '2a/b2'].join(':'),
-		[v, 'arrival', 'another:stop', 'some-line', 1546333800, '2a/b2'].join(':'),
-		[v, 'arrival', 'some-stop', 'another:line', 1546333800, '2a/b2'].join(':'),
-		[v, 'arrival', 'another:stop', 'another:line', 1546333800, '2a/b2'].join(':')
+		[[v, 'arrival', 'some-stop', 'some-line', 1546333800, '2a/b2'].join(':'), 20 + 10 + 30],
+		[[v, 'arrival', 'another:stop', 'some-line', 1546333800, '2a/b2'].join(':'), 31 + 10 + 30],
+		[[v, 'arrival', 'some-stop', 'another:line', 1546333800, '2a/b2'].join(':'), 20 + 11 + 30],
+		[[v, 'arrival', 'another:stop', 'another:line', 1546333800, '2a/b2'].join(':'), 31 + 11 + 30],
 	])
 
 	t.end()
 })
 
 test('trip IDs', (t) => {
-	const lineIds = ['some-line', 'another:line']
+	const lineIds = [['some-line', 10], ['another:line', 11]]
 	const depsIds = [
-		['dep0a', 'dep0b', 'dep0c'],
-		['dep1a', 'dep1b', 'dep1c'],
-		['dep2a', 'dep2b'], // note: just 2 IDs
+		[['dep0a', 40], ['dep0b', 50], ['dep0c', 51]],
+		[['dep1a', 40], ['dep1b', 41], ['dep1c', 50]],
+		[['dep2a', 30], ['dep2b', 50]], // note: just 2 IDs
 	]
 	const arrsIds = [
-		['arr0'],
-		['arr1a', 'arr1b'], // note: 2 IDs
-		['arr2'],
+		[['arr0', 42]],
+		[['arr1a', 40], ['arr1b', 60]], // note: 2 IDs
+		[['arr2', 50]],
 	]
 
 	const ids = tripIds('sauce', lineIds, depsIds, arrsIds)({
@@ -151,30 +157,30 @@ test('trip IDs', (t) => {
 		},
 	})
 	t.deepEqual(ids, [
-		[v, 'sauce', 'trip-12345'].join(':'), // data src + trip ID
+		[[v, 'sauce', 'trip-12345'].join(':'), 20], // data src + trip ID
 
 		// line IDs + fahrt nr
-		[v, 'some-line', '12345'].join(':'),
-		[v, 'another:line', '12345'].join(':'),
+		[[v, 'some-line', '12345'].join(':'), 10 + 30],
+		[[v, 'another:line', '12345'].join(':'), 11 + 30],
 
 		// line ID + first departure ID
-		[v, 'some-line', 'dep0a'].join(':'),
-		[v, 'another:line', 'dep0a'].join(':'),
-		[v, 'some-line', 'dep0b'].join(':'),
-		[v, 'another:line', 'dep0b'].join(':'),
-		[v, 'some-line', 'dep0c'].join(':'),
-		[v, 'another:line', 'dep0c'].join(':'),
+		[[v, 'some-line', 'dep0a'].join(':'), 40 + 10 + 21],
+		[[v, 'another:line', 'dep0a'].join(':'), 40 + 11 + 21],
+		[[v, 'some-line', 'dep0b'].join(':'), 50 + 10 + 21],
+		[[v, 'another:line', 'dep0b'].join(':'), 50 + 11 + 21],
+		[[v, 'some-line', 'dep0c'].join(':'), 51 + 10 + 21],
+		[[v, 'another:line', 'dep0c'].join(':'), 51 + 11 + 21],
 
 		// all departures' IDs
-		v + ':' + hash(['dep0a', 'dep1a', 'dep2a'].join(':')),
-		v + ':' + hash(['dep0b', 'dep1b', 'dep2b'].join(':')),
+		[v + ':' + hash(['dep0a', 'dep1a', 'dep2a'].join(':')), 40 + 20],
+		[v + ':' + hash(['dep0b', 'dep1b', 'dep2b'].join(':')), 50 + 20],
 
 		// line ID + first arrival ID
-		[v, 'some-line', 'arr0'].join(':'),
-		[v, 'another:line', 'arr0'].join(':'),
+		[[v, 'some-line', 'arr0'].join(':'), 42 + 10 + 21],
+		[[v, 'another:line', 'arr0'].join(':'), 42 + 11 + 21],
 
 		// all arrivals' IDs
-		v + ':' + hash(['arr0', 'arr1a', 'arr2'].join(':')),
+		[v + ':' + hash(['arr0', 'arr1a', 'arr2'].join(':')), 50 + 20],
 	])
 
 	t.end()


### PR DESCRIPTION
@hbruch

This is a draft to add a notion of specificity to each computed ID; An ID's specificity *roughly* describes how precisely the ID describes or how well it distinguishes its item from others.

For example, this enables a more precise matching logic in `match-gtfs-rt-to-gtfs` where two very "sparse" (with just basic fields) stops from data source A *both* match the stop from data source B, e.g. because one shares the name and the other is nearby; In this case, a matching by name is obviously more precise than matching by distance.

What I don't like: This PR changes `stable-public-transport-ids` from a very simple notion of "if two operators/lines/stops/departures/arrivals/trips have any overlapping ID, they are equal" (which is wrong in the case described above) to "if they have any overlapping ID, consider the specificity and compare it with overlapping IDs of others". The PR introduces a mechanism that can be made arbitrarily complex, and that seems to express more precision than it actually does.

What do you think? Is there a better way to solve this?